### PR TITLE
Prevent environment file cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,31 @@ It's recommended to match the version of docker-cra npm version with the docker-
 ## To Do
 
 - Support version bumping the app and supporting old chunks that client's might not have loaded
+
+## Local Development
+
+Building and testing locally is best done along with the companion repo [docker-cra-example](https://github.com/danielemery/docker-cra-example).
+
+In this repo you can run the following commands to make the local build available to the example project.
+
+```sh
+npm run build && npm link
+docker build -t docker-cra:latest .
+```
+
+And then in the example run the following to consume and test.
+
+```sh
+# Install dependencies
+npm ci
+npm link docker-cra
+
+# Local dev test
+npm start
+
+# Docker test
+# Note: First update Dockerfile to use the local build with `FROM docker-cra`
+npm run build
+docker build -t docker-cra-example .
+docker run --env-file=.env -p 8080:80 docker-cra-example
+```

--- a/README.md
+++ b/README.md
@@ -77,10 +77,4 @@ npm link docker-cra
 
 # Local dev test
 npm start
-
-# Docker test
-# Note: First update Dockerfile to use the local build with `FROM docker-cra`
-npm run build
-docker build -t docker-cra-example .
-docker run --env-file=.env -p 8080:80 docker-cra-example
 ```

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ For a working example see the [docker-cra-example](https://github.com/danielemer
 
 A joi schema is required to validate incoming environment variables. This serves two purposes:
 
-1. As window.env.js is public the schema ensures nothing sensitive ends up in the file
-2. As we have no validation of env variable types at compile type, we need to ensure they are correctly provided at runtime
+1. As `window.env.js` is public, the schema ensures nothing sensitive ends up in the file.
+2. As we have no validation of env variable types at compile type, we need to ensure they are provided and correctly typed at runtime.
 
-A file called `.env.schema.js` should be created in the root of the project with any environment variables defined. `docker-cra` also supports the following built-in environment variables:
+A file called `env.schema.js` should be created in the root of the project with all required environment variables defined. In additional to those defined, `docker-cra` automatically supports the following environment variables:
 
 - `REACT_APP_CLIENT_VERSION` (required string)
 - `PUBLIC_URL` (serve path - or leave blank to serve at `/`)
@@ -51,7 +51,7 @@ COPY env.schema.js ./env.schema.js
 COPY build /usr/share/nginx/html
 ```
 
-It's recommended to match the version of docker-cra npm version with the docker-cra docker tag version.
+It's recommended to match the version of `docker-cra` npm version with the `docker-cra` docker tag version to ensure local development more closely mirrors docker deploys.
 
 ## To Do
 

--- a/docker-cra-entrypoint.sh
+++ b/docker-cra-entrypoint.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
+docker-cra --version
 docker-cra -d ../share/nginx/html -s ./env.schema.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-cra",
-  "version": "0.1.2",
+  "version": "0.1.3-env-cache-invalidation.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-cra",
-  "version": "0.1.3-env-cache-invalidation.0",
+  "version": "0.1.3-env-cache-invalidation.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-cra",
-  "version": "0.1.2",
+  "version": "0.1.3-env-cache-invalidation.0",
   "description": "npm cli utility to assist serving create-react-app projects out of a docker container",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-cra",
-  "version": "0.1.3-env-cache-invalidation.0",
+  "version": "0.1.3-env-cache-invalidation.1",
   "description": "npm cli utility to assist serving create-react-app projects out of a docker container",
   "main": "dist/index.js",
   "bin": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,2 @@
 export const ENVIRONMENT_DEFINITION_FILE_NAME = 'window.env.js';
+export const REQUIRED_INDEX_SCRIPT = `<script src="%PUBLIC_URL%/window.env.js"></script>`;

--- a/src/environments.ts
+++ b/src/environments.ts
@@ -3,7 +3,7 @@ export type EnvironmentType = 'local' | 'docker';
 export function getIndexPath(environmentType: EnvironmentType) {
   switch (environmentType) {
     case 'docker':
-      return 'build/index.html';
+      return 'index.html';
     case 'local':
       return 'public/index.html';
     default:

--- a/src/environments.ts
+++ b/src/environments.ts
@@ -1,0 +1,12 @@
+export type EnvironmentType = 'local' | 'docker';
+
+export function getIndexPath(environmentType: EnvironmentType) {
+  switch (environmentType) {
+    case 'docker':
+      return 'build/index.html';
+    case 'local':
+      return 'public/index.html';
+    default:
+      throw new Error(`Unknown environment type: ${environmentType}`);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 
 import initialiseEnvironmentVariables from './init-env';
 import performPreChecks from './pre-checks';
-import { EnvironmentType } from './types';
+import { EnvironmentType } from './environments';
 
 const pjson = require('../package.json');
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,15 +2,16 @@ import { Command } from 'commander';
 
 import initialiseEnvironmentVariables from './init-env';
 import performPreChecks from './pre-checks';
+import { EnvironmentType } from './types';
 
 const pjson = require('../package.json');
 
 async function processCommands(
   destinationFilePath: string,
   schemaPath: string,
-  environmentType: 'local' | 'docker',
+  environmentType: EnvironmentType,
 ): Promise<void> {
-  await performPreChecks(environmentType === 'local');
+  await performPreChecks(environmentType);
   await initialiseEnvironmentVariables(
     destinationFilePath,
     schemaPath,
@@ -29,7 +30,7 @@ function runOrTimeout(command: Promise<void>) {
     });
 }
 
-export function cli(args: string[]) {
+export function cli() {
   const program = new Command();
   program
     .requiredOption(

--- a/src/init-env.ts
+++ b/src/init-env.ts
@@ -83,7 +83,6 @@ export default async function initEnv(
     environmentType === 'docker' ? `${environmentFileHash}.` : '';
   const environmentFileName = `${fileNamePrefix}${ENVIRONMENT_DEFINITION_FILE_NAME}`;
   const envFileDestination = path.join(
-    process.cwd(),
     destinationFilePath,
     environmentFileName,
   );
@@ -96,7 +95,10 @@ export default async function initEnv(
 
   // If required write result to index.html
   if (environmentType === 'docker') {
-    const indexPath = path.join(process.cwd(), getIndexPath(environmentType));
+    const indexPath = path.join(
+      destinationFilePath,
+      getIndexPath(environmentType),
+    );
     const publicUrl =
       process.env.PUBLIC_URL === '/' ? '' : process.env.PUBLIC_URL;
     const expectedIndexScript = REQUIRED_INDEX_SCRIPT.replace(

--- a/src/init-env.ts
+++ b/src/init-env.ts
@@ -1,10 +1,15 @@
 import { promises as fs } from 'fs';
 import path from 'path';
+import { createHash } from 'crypto';
 import Joi from 'joi';
 import dotenv from 'dotenv';
 
 import DockerCRABaseEnvType from './base-environment-type';
-import { ENVIRONMENT_DEFINITION_FILE_NAME } from './constants';
+import {
+  ENVIRONMENT_DEFINITION_FILE_NAME,
+  REQUIRED_INDEX_SCRIPT,
+} from './constants';
+import { EnvironmentType, getIndexPath } from './environments';
 
 const baseSchema = Joi.object<DockerCRABaseEnvType>({
   REACT_APP_CLIENT_VERSION: Joi.string().required(),
@@ -28,11 +33,22 @@ function validateEnvironmentVariables<T>(
   return joiResult.value;
 }
 
+async function findAndReplaceInFile(
+  filePath: string,
+  fromSearchValue: RegExp | string,
+  toSearchFile: string,
+) {
+  const data = await fs.readFile(filePath, 'utf8');
+  const result = data.replace(fromSearchValue, toSearchFile);
+  await fs.writeFile(filePath, result, 'utf8');
+}
+
 export default async function initEnv(
   destinationFilePath: string,
   schemaPath: string,
-  environmentType: 'local' | 'docker',
+  environmentType: EnvironmentType,
 ) {
+  // Local builds should read from `.env` file if available.
   if (environmentType === 'local') {
     const result = dotenv.config();
     if (result.error) {
@@ -40,15 +56,10 @@ export default async function initEnv(
     }
   }
 
-  const finalDestination = path.join(
-    process.cwd(),
-    destinationFilePath,
-    ENVIRONMENT_DEFINITION_FILE_NAME,
-  );
-  const finalSchema = path.join(process.cwd(), schemaPath);
-  console.log(`Writing window env file to ${finalDestination}`);
-  console.log(`Attempting to load schema from ${finalSchema}`);
-  const providedSchema = require(finalSchema);
+  // Perform environment variable validation.
+  const schemaLocation = path.join(process.cwd(), schemaPath);
+  console.log(`Attempting to load schema from ${schemaLocation}`);
+  const providedSchema = require(schemaLocation);
   const envSchema = baseSchema.concat(providedSchema);
   console.log('Validating environment variables');
   const validatedWindowVariables = validateEnvironmentVariables(
@@ -56,16 +67,55 @@ export default async function initEnv(
     process.env,
   );
 
-  console.log('Writing environment variables to file.');
+  // Prepare file and calculate hash
+  console.log('Attempting to generate environment file.');
   const mappedWindowVariables = Object.entries(validatedWindowVariables).map(
     (entry) => `${entry[0]}:'${entry[1]}'`,
   );
   const windowVariablesToBeWrittenToFile = `window.env={${mappedWindowVariables}};`;
+  const environmentFileHash = createHash('md5')
+    .update(windowVariablesToBeWrittenToFile)
+    .digest('hex');
+  console.log(`Environment file generated with hash [${environmentFileHash}]`);
+
+  // Write environment file
+  const fileNamePrefix =
+    environmentType === 'docker' ? `${environmentFileHash}.` : '';
+  const environmentFileName = `${fileNamePrefix}${ENVIRONMENT_DEFINITION_FILE_NAME}`;
+  const envFileDestination = path.join(
+    process.cwd(),
+    destinationFilePath,
+    environmentFileName,
+  );
+  console.log(`Writing window env file to ${envFileDestination}`);
   await fs.writeFile(
-    finalDestination,
+    envFileDestination,
     windowVariablesToBeWrittenToFile,
     'utf8',
   );
+
+  // If required write result to index.html
+  if (environmentType === 'docker') {
+    const indexPath = path.join(process.cwd(), getIndexPath(environmentType));
+    const publicUrl =
+      process.env.PUBLIC_URL === '/' ? '' : process.env.PUBLIC_URL;
+    const expectedIndexScript = REQUIRED_INDEX_SCRIPT.replace(
+      '%PUBLIC_URL%',
+      publicUrl || '',
+    );
+    const desiredIndexScript = expectedIndexScript.replace(
+      'window.env.js',
+      environmentFileName,
+    );
+    console.log(
+      `Attempting to replace ${expectedIndexScript} with ${desiredIndexScript} in ${indexPath}`,
+    );
+    await findAndReplaceInFile(
+      indexPath,
+      expectedIndexScript,
+      desiredIndexScript,
+    );
+  }
 
   console.log('Environment variables initialised successfully');
 }

--- a/src/pre-checks.ts
+++ b/src/pre-checks.ts
@@ -1,8 +1,7 @@
 import { promises as fs } from 'fs';
 import path from 'path';
-import { EnvironmentType } from './types';
-
-const REQUIRED_INDEX_SCRIPT = `<script src="%PUBLIC_URL%/window.env.js"></script>`;
+import { REQUIRED_INDEX_SCRIPT } from './constants';
+import { EnvironmentType } from './environments';
 
 export default async function performPreChecks(
   environmentType: EnvironmentType,

--- a/src/pre-checks.ts
+++ b/src/pre-checks.ts
@@ -1,18 +1,26 @@
 import { promises as fs } from 'fs';
 import path from 'path';
+import { EnvironmentType } from './types';
 
 const REQUIRED_INDEX_SCRIPT = `<script src="%PUBLIC_URL%/window.env.js"></script>`;
 
-export default async function performPreChecks(isLocal: boolean) {
-  if (isLocal) {
-    try {
-      const indexPath = path.join(process.cwd(), `./public/index.html`);
-      const file = await fs.readFile(indexPath, "utf8");
-      if (file.indexOf(REQUIRED_INDEX_SCRIPT) < 0) {
-        throw new Error(`Could not find required script ${REQUIRED_INDEX_SCRIPT} in ${indexPath}`);
+export default async function performPreChecks(
+  environmentType: EnvironmentType,
+) {
+  switch (environmentType) {
+    case 'local':
+      try {
+        const indexPath = path.join(process.cwd(), `./public/index.html`);
+        const file = await fs.readFile(indexPath, 'utf8');
+        if (file.indexOf(REQUIRED_INDEX_SCRIPT) < 0) {
+          throw new Error(
+            `Could not find required script ${REQUIRED_INDEX_SCRIPT} in ${indexPath}`,
+          );
+        }
+      } catch (err: any) {
+        throw new Error(`Project not set up for local ${err?.message}`);
       }
-    } catch (err: any) {
-      throw new Error(`Project not set up for local ${err?.message}`);
-    }
+    default:
+      return;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,1 @@
+export type EnvironmentType = 'local' | 'docker';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,1 +1,0 @@
-export type EnvironmentType = 'local' | 'docker';


### PR DESCRIPTION
Closes #5 

- When generating the window.env.js file calculate and include a hash in the filename
- Leave local dev unchanged